### PR TITLE
Docker: Change base image containing XDebug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM brettt89/silverstripe-web:7.1-alpine
+FROM brettt89/silverstripe-web:7.1-platform
 
 LABEL maintainer="Marco Hermo"
 

--- a/src/Services/SchemaService.php
+++ b/src/Services/SchemaService.php
@@ -113,7 +113,7 @@ class SchemaService extends ViewableData
         $boostedFields = $this->index->getBoostedFields();
         foreach ($field as $name => $options) {
             // Temporary short-name solution until the Introspection is properly solved
-            $name = explode ('\\', $name);
+            $name = explode('\\', $name);
             $name = end($name);
             // Boosted fields are always stored
             $store = ($this->store || array_key_exists($fieldName, $boostedFields)) ? 'true' : 'false';


### PR DESCRIPTION
Base image source: https://github.com/brettt89/silverstripe-web
7.1-platform contains XDebug pre-installed.
Have pushed the built image on docker hub as well.