### PR TITLE
Solr Permission Fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,16 @@ jobs:
             RESPONSE=$(echo $(curl http://localhost:8983/solr/CircleCITestIndex/select?q=*) | grep -o '"numFound":5')
             if [[ -z "$RESPONSE" ]]; then echo "No indexed documents"; exit 1; fi
             echo "Solr has successfully indexed documents"
-      - run: vendor/bin/phpunit --coverage-clover=coverage.xml --log-junit ./coverage/junit.xml -d memory_limit=512M tests/unit
+      - run:
+          name: Permission changes and testing
+          command: |
+            usermod -a -G www-data solr
+            groups solr
+            usermod -a -G solr www-data
+            groups www-data
+            chown -R solr:www-data /var/www/html
+            chmod -R u+rwxs,g+rwxs /var/www/html
+      - run: su solr -s $SHELL -c 'vendor/bin/phpunit --coverage-clover=coverage.xml --log-junit ./coverage/junit.xml -d memory_limit=512M tests/unit'
       - run: bash <(curl -s https://codecov.io/bash) -f coverage.xml
       - run: vendor/bin/phpcs --standard=phpcs.xml.dist src
       - store_test_results:

--- a/tests/unit/SolrConfigureJobTest.php
+++ b/tests/unit/SolrConfigureJobTest.php
@@ -27,14 +27,12 @@ class SolrConfigureJobTest extends SapphireTest
         $this->assertEquals('Configure new or re-configure existing Solr cores', $this->job->getTitle());
     }
 
-    // @todo fix the permission issues etc.
-//    public function testProcess()
-//    {
-//        $this->job->process();
-//
-//        $solrResponse = file_get_contents('http://localhost:8983/solr/TestIndex/admin/ping');
-//        $response = json_decode($solrResponse);
-//        $this->assertEquals('OK', $response->status);
-//        $this->assertEquals('10', $response->params->rows);
-//    }
+    public function testProcess()
+    {
+        $this->job->process();
+        $solrResponse = file_get_contents('http://localhost:8983/solr/TestIndex/admin/ping');
+        $response = json_decode($solrResponse);
+        $this->assertEquals('OK', $response->status);
+        $this->assertEquals('10', $response->responseHeader->params->rows);
+    }
 }


### PR DESCRIPTION
New versions of Solr runs the server with 'solr' user and group account.
This have write permission errors when running build tasks and unit tests.
Invert the owner permission of `/var/www/html` to `solr:www-data`
Then run phpunit as solr user.