### PR TITLE
Initial addition of support for fluent through hooks

### DIFF
--- a/Solr/5/templates/schema.ss
+++ b/Solr/5/templates/schema.ss
@@ -56,16 +56,16 @@
         <field name='ClassName' type='string' indexed='true' stored='true' required='true'/>
         <field name='ClassHierarchy' type='string' indexed='true' stored='true' required='true' multiValued='true'/>
         <field name='ViewStatus' type='string' indexed='true' stored='true' required='true' multiValued='true'/>
-<%--        Copyfields--%>
+        <!--        Copyfields -->
         <% loop $CopyFields %>
             <field name='$Field' type='htmltext' indexed='true' stored='true' multiValued='true'/>
         <% end_loop %>
-<%--        Fulltext fields--%>
+        <!--        Fulltext fields -->
         <% loop $FulltextFieldDefinitions %>
             <field name='$Field' type='$Type' indexed='$Indexed' stored='$Stored' multiValued='$MultiValued'/>
         <% end_loop %>
 
-<%--        Filter/Facet fields--%>
+        <!--        Filter/Facet fields -->
         <% loop $FilterFieldDefinitions %>
             <field name='$Field' type='$Type' indexed='$Indexed' stored='$Stored' multiValued='$MultiValued'/>
         <% end_loop %>

--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -1,7 +1,6 @@
-# Enable the following for extensive debug output
-Firesphere\SolrSearch\Indexes\BaseIndex:
-  extensions:
-    - Firesphere\SolrSearch\Compat\SubsitesExtension # Subsites compatibility
 SilverStripe\ORM\DataObject:
   extensions:
     - Firesphere\SolrSearch\Extensions\DataObjectExtension
+Firesphere\SolrSearch\Indexes\BaseIndex:
+  extensions:
+    - Firesphere\SolrSearch\Compat\SubsitesExtension # Subsites compatibility

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "ext-json": "*",
     "silverstripe/framework": "^4",
     "silverstripe/queuedjobs": "^4",
-    "solarium/solarium": "^4.2",
+    "solarium/solarium": "^5.0",
     "minimalcode/search": "^1.0",
     "guzzlehttp/guzzle": "^6.3"
   },

--- a/src/Admins/SearchAdmin.php
+++ b/src/Admins/SearchAdmin.php
@@ -2,23 +2,20 @@
 
 namespace Firesphere\SolrSearch\Admins;
 
-use Firesphere\SolrSearch\Models\SearchClass;
-use SilverStripe\Admin\ModelAdmin;
-
 /**
  * Class \Firesphere\SolrSearch\Admins\SearchAdmin
  * @todo implement search administration, e.g. Elevation and Facets
  *
-class SearchAdmin extends ModelAdmin
-{
-    private static $managed_models = [
-        SearchClass::class
-    ];
-
-    private static $menu_icon_class = 'font-icon-search';
-
-    private static $url_segment = 'searchadmin';
-
-    private static $menu_title = 'Search';
-}
-/** **/
+ * class SearchAdmin extends ModelAdmin
+ * {
+ * private static $managed_models = [
+ * SearchClass::class
+ * ];
+ *
+ * private static $menu_icon_class = 'font-icon-search';
+ *
+ * private static $url_segment = 'searchadmin';
+ *
+ * private static $menu_title = 'Search';
+ * }
+ * /** **/

--- a/src/Extensions/DataObjectExtension.php
+++ b/src/Extensions/DataObjectExtension.php
@@ -212,6 +212,7 @@ class DataObjectExtension extends DataExtension
 
         if ($owner->canView(null)) {
             self::$canViewClasses[$owner->ClassName] = ['1-null'];
+
             // Anyone can view
             return ['1-null'];
         }

--- a/src/Factories/DocumentFactory.php
+++ b/src/Factories/DocumentFactory.php
@@ -16,16 +16,18 @@ use LogicException;
 use Psr\Log\LoggerInterface;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDate;
 use SilverStripe\ORM\FieldType\DBField;
-use Solarium\QueryType\Update\Query\Document\Document;
+use Solarium\QueryType\Update\Query\Document;
 use Solarium\QueryType\Update\Query\Query;
 
 class DocumentFactory
 {
     use Configurable;
+    use Extensible;
     use DocumentFactoryTrait;
     use LoggerTrait;
 
@@ -142,6 +144,8 @@ class DocumentFactory
             return;
         }
 
+        $this->extend('onBeforeAddField', $field);
+
         try {
             $valuesForField = [DataResolver::identify($object, $field['field'])];
         } catch (Exception $e) {
@@ -155,6 +159,7 @@ class DocumentFactory
             if ($value === null) {
                 continue;
             }
+            $this->extend('onBeforeAddDoc', $field, $value);
             $this->addToDoc($doc, $field, $type, $value);
         }
     }
@@ -204,7 +209,7 @@ class DocumentFactory
 
         $name = getShortFieldName($field['name']);
 
-        $doc->addField($name, $value);
+        $doc->addField($name, $value, null, Document::MODIFIER_SET);
     }
 
     /**

--- a/src/Helpers/DataResolver.php
+++ b/src/Helpers/DataResolver.php
@@ -43,24 +43,6 @@ class DataResolver
     }
 
     /**
-     * @param DataObject|ArrayData|SS_List $component
-     * @param array $columns
-     *
-     * @return void
-     * @throws LogicException
-     */
-    protected function cannotIdentifyException($component, $columns = []): void
-    {
-        throw new LogicException(
-            sprintf(
-                'Cannot identify, "%s" from class "%s"',
-                implode('.', $columns),
-                ClassInfo::shortName($component)
-            )
-        );
-    }
-
-    /**
      * @param DataObject|ArrayData|SS_List|DBField $obj
      * @param array|string $columns
      *
@@ -79,5 +61,23 @@ class DataResolver
         }
 
         throw new LogicException(sprintf('Class: %s is not supported.', ClassInfo::shortName($obj)));
+    }
+
+    /**
+     * @param DataObject|ArrayData|SS_List $component
+     * @param array $columns
+     *
+     * @return void
+     * @throws LogicException
+     */
+    protected function cannotIdentifyException($component, $columns = []): void
+    {
+        throw new LogicException(
+            sprintf(
+                'Cannot identify, "%s" from class "%s"',
+                implode('.', $columns),
+                ClassInfo::shortName($component)
+            )
+        );
     }
 }

--- a/src/Indexes/BaseIndex.php
+++ b/src/Indexes/BaseIndex.php
@@ -169,9 +169,10 @@ abstract class BaseIndex
      */
     public function doSearch(BaseQuery $query)
     {
-        $this->extend('onBeforeSearch', $query);
         // Build the actual query parameters
         $clientQuery = $this->buildSolrQuery($query);
+
+        $this->extend('onBeforeSearch', $query, $clientQuery);
 
         $result = $this->client->select($clientQuery);
 
@@ -269,7 +270,7 @@ abstract class BaseIndex
         // Return values to make the key reset
         // Only return unique values
         // And make it all a single array
-        return array_values(
+        $fields = array_values(
             array_unique(
                 array_merge(
                     $this->getFulltextFields(),
@@ -279,6 +280,10 @@ abstract class BaseIndex
                 )
             )
         );
+
+        $this->extend('updateFieldsForIndexing', $fields);
+
+        return $fields;
     }
 
     /**

--- a/src/Services/SchemaService.php
+++ b/src/Services/SchemaService.php
@@ -51,6 +51,8 @@ class SchemaService extends ViewableData
             $this->getFieldDefinition($field, $return);
         }
 
+        $this->extend('onBeforeFulltextFields', $return);
+
         $this->setStore($store);
 
         return $return;
@@ -67,6 +69,7 @@ class SchemaService extends ViewableData
         $field = $this->introspection->resolveField($fieldName);
         $typeMap = Statics::getTypeMap();
         $storeFields = $this->getStoreFields();
+        $item = [];
         foreach ($field as $name => $options) {
             // Temporary short-name solution until the Introspection is properly solved
             $name = getShortFieldName($name);
@@ -82,6 +85,8 @@ class SchemaService extends ViewableData
             ];
             $return->push($item);
         }
+
+        $this->extend('onAfterFieldDefinition', $return, $item);
     }
 
     /**
@@ -117,6 +122,8 @@ class SchemaService extends ViewableData
 
             $return->push($item);
         }
+
+        $this->extend('onBeforeCopyFields', $return);
 
         return $return;
     }
@@ -162,6 +169,7 @@ class SchemaService extends ViewableData
         foreach ($fields as $field) {
             $this->getFieldDefinition($field, $return);
         }
+        $this->extend('onBeforeFilterFields', $return);
 
         $this->setStore($originalStore);
 

--- a/src/Traits/DataResolverTraits/DataResolveTrait.php
+++ b/src/Traits/DataResolverTraits/DataResolveTrait.php
@@ -113,6 +113,7 @@ trait DataResolveTrait
 
         return $value;
     }
+
     /**
      * Resolves a DataObject value
      * @return mixed
@@ -123,50 +124,19 @@ trait DataResolveTrait
         if (empty($this->columnName)) {
             return $this->component->toMap();
         }
-        if ($return = $this->componentHasMethod()) {
-            return $return;
-        }
-        if ($return = $this->componentHasField()) {
-            return $return;
-        }
-
-        $this->cannotIdentifyException($this->component, [$this->columnName]);
-    }
-
-    /**
-     * If a component has a method, return the method outcome
-     *
-     * @return bool|string|array|SS_List
-     */
-    protected function componentHasMethod()
-    {
-        $return = false;
         // Inspect component for element $relation
         if ($this->component->hasMethod($this->columnName)) {
             $relation = $this->columnName;
             // We hit a direct method that returns a non-object
             if (!is_object($this->component->$relation())) {
-                $return = $this->component->$relation();
-            } else {
-                $return = self::identify($this->component->$relation(), $this->columns);
+                return $this->component->$relation();
             }
+
+            return self::identify($this->component->$relation(), $this->columns);
         }
-
-        return $return;
-    }
-
-    /**
-     * If a component has the field, attempt to return the field value
-     *
-     * @return bool|array|string
-     */
-    protected function componentHasField()
-    {
-        $return = false;
         // Inspect component has attribute
         if ($this->component->hasField($this->columnName)) {
             $data = $this->component->{$this->columnName};
-            $return = $data;
             $dbObject = $this->component->dbObject($this->columnName);
             if ($dbObject) {
                 // @todo do we need to set the value?
@@ -174,9 +144,9 @@ trait DataResolveTrait
 
                 return self::identify($dbObject, $this->columns);
             }
+
+            return $data;
         }
-
-        return $return;
+        $this->cannotIdentifyException($this->component, [$this->columnName]);
     }
-
 }

--- a/src/Traits/IndexTraits/BaseIndexTrait.php
+++ b/src/Traits/IndexTraits/BaseIndexTrait.php
@@ -237,10 +237,6 @@ trait BaseIndexTrait
     {
         $this->copyFields[$field] = $options;
 
-        if (!in_array($field, $this->getFulltextFields(), true)) {
-            $this->addFulltextField($field);
-        }
-
         return $this;
     }
 

--- a/tests/unit/DocumentFactoryTest.php
+++ b/tests/unit/DocumentFactoryTest.php
@@ -16,7 +16,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\SiteConfig\SiteConfig;
 use SilverStripe\View\ViewableData;
 use Solarium\Core\Client\Client;
-use Solarium\QueryType\Update\Query\Document\Document;
+use Solarium\QueryType\Update\Query\Document;
 
 class DocumentFactoryTest extends SapphireTest
 {

--- a/tests/unit/SolrCoreServiceTest.php
+++ b/tests/unit/SolrCoreServiceTest.php
@@ -19,6 +19,7 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DB;
 use Solarium\Core\Client\Client;
 
 class SolrCoreServiceTest extends SapphireTest
@@ -72,7 +73,7 @@ class SolrCoreServiceTest extends SapphireTest
     }
 
     /**
-     * @expectedException LogicException
+     * @expectedException \LogicException
      */
     public function testWrongUpdateItems()
     {


### PR DESCRIPTION
- Directly needed for Fluent

Add extension hooks useable for Fluent

- Fluent extension is in the compatibility module

Upgrade Solarium to the latest version

The modifier should not be add, but set

# Note
This whole PR is to enable Fluent, which is in the compatibility module. I've not yet given it a thought on how to manage all these modules, but I think a set of separate micro-modules would do the job

**Todo**
Make the task or background job index run all languages. Awaiting Tractorcow his response.