### PR TITLE
Fix #143 unsetting ShowInSearch not removing object from Index

### DIFF
--- a/src/Extensions/DataObjectExtension.php
+++ b/src/Extensions/DataObjectExtension.php
@@ -91,7 +91,7 @@ class DataObjectExtension extends DataExtension
             Versioned::set_reading_mode(Versioned::DEFAULT_MODE);
             $service->setInDebugMode(false);
             $type = SolrCoreService::UPDATE_TYPE;
-            // If the object should show in search, remove it
+            // If the object should not show in search, remove it
             if ($owner->ShowInSearch === 0) {
                 $type = SolrCoreService::DELETE_TYPE;
             }

--- a/src/Extensions/DataObjectExtension.php
+++ b/src/Extensions/DataObjectExtension.php
@@ -95,7 +95,7 @@ class DataObjectExtension extends DataExtension
             if ($owner->ShowInSearch === 0) {
                 $type = SolrCoreService::DELETE_TYPE;
             }
-            $service->updateItems(ArrayList::create([$owner]),$type);
+            $service->updateItems(ArrayList::create([$owner]), $type);
             // If we don't get an exception, mark the item as clean
             // Added bonus, array_flip removes duplicates
             $this->clearIDs($owner, $ids, $record);

--- a/src/Extensions/DataObjectExtension.php
+++ b/src/Extensions/DataObjectExtension.php
@@ -90,7 +90,12 @@ class DataObjectExtension extends DataExtension
         try {
             Versioned::set_reading_mode(Versioned::DEFAULT_MODE);
             $service->setInDebugMode(false);
-            $service->updateItems(ArrayList::create([$owner]), SolrCoreService::UPDATE_TYPE);
+            $type = SolrCoreService::UPDATE_TYPE;
+            // If the object should show in search, remove it
+            if ($owner->ShowInSearch === 0) {
+                $type = SolrCoreService::DELETE_TYPE;
+            }
+            $service->updateItems(ArrayList::create([$owner]),$type);
             // If we don't get an exception, mark the item as clean
             // Added bonus, array_flip removes duplicates
             $this->clearIDs($owner, $ids, $record);


### PR DESCRIPTION
When a page was indexed, and then set as "do not show in search", the page would not be properly removed from the index, causing it to show up in search despite the flag being unset.