### PR TITLE
Add caching to the lookups

### DIFF
--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -1,0 +1,5 @@
+SilverStripe\Core\Injector\Injector:
+  Psr\SimpleCache\CacheInterface.SolrCache:
+    factory: SilverStripe\Core\Cache\CacheFactory
+    constructor:
+      namespace: "SolrCache"

--- a/src/Tasks/SolrConfigureTask.php
+++ b/src/Tasks/SolrConfigureTask.php
@@ -18,6 +18,8 @@ use Firesphere\SolrSearch\Stores\FileConfigStore;
 use Firesphere\SolrSearch\Stores\PostConfigStore;
 use Firesphere\SolrSearch\Traits\LoggerTrait;
 use GuzzleHttp\Exception\GuzzleException;
+use Psr\SimpleCache\CacheInterface;
+use Psr\SimpleCache\InvalidArgumentException;
 use ReflectionException;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Injector\Injector;
@@ -71,9 +73,13 @@ class SolrConfigureTask extends BuildTask
      * @throws ReflectionException
      * @throws ValidationException
      * @throws GuzzleException
+     * @throws InvalidArgumentException
      */
     public function run($request)
     {
+        /** @var CacheInterface $cache */
+        $cache = Injector::inst()->get(CacheInterface::class . '.SolrCache');
+        $cache->delete('ValidClasses');
         $this->extend('onBeforeSolrConfigureTask', $request);
 
         $indexes = (new SolrCoreService())->getValidIndexes();
@@ -105,8 +111,6 @@ class SolrConfigureTask extends BuildTask
      * Update the index on the given store
      *
      * @param string $index Core to index
-     * @throws ValidationException
-     * @throws GuzzleException
      */
     protected function configureIndex($index): void
     {

--- a/tests/unit/DataObjectExtensionTest.php
+++ b/tests/unit/DataObjectExtensionTest.php
@@ -11,8 +11,10 @@ use Firesphere\SolrSearch\Services\SolrCoreService;
 use Firesphere\SolrSearch\Tasks\SolrConfigureTask;
 use Page;
 use Psr\Log\NullLogger;
+use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\NullHTTPRequest;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
@@ -126,8 +128,10 @@ class DataObjectExtensionTest extends SapphireTest
     {
         $url = Controller::curr()->getRequest()->getURL();
         Controller::curr()->getRequest()->setUrl('dev/build');
-        $this->assertNull((new DataObjectExtension())->onAfterWrite());
-        $this->assertNull((new DataObjectExtension())->onAfterPublish());
+        $extension = new DataObjectExtension();
+        $extension->setOwner(new DataObject());
+        $this->assertNull($extension->onAfterWrite());
+        $this->assertNull($extension->onAfterPublish());
         Controller::curr()->getRequest()->setUrl($url);
     }
 
@@ -157,6 +161,9 @@ class DataObjectExtensionTest extends SapphireTest
 
     protected function setUp()
     {
+        /** @var CacheInterface $cache */
+        $cache = Injector::inst()->get(CacheInterface::class . '.SolrCache');
+        $cache->delete('ValidClasses');
         $task = new SolrConfigureTask();
         $task->setLogger(new NullLogger());
         $task->run(new NullHTTPRequest());

--- a/tests/unit/SolrCoreServiceTest.php
+++ b/tests/unit/SolrCoreServiceTest.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Page;
+use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Admin\ModelAdmin;
 use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\CMS\Model\SiteTree;
@@ -175,6 +176,11 @@ class SolrCoreServiceTest extends SapphireTest
             VirtualPage::class,
         ];
         $this->assertEquals($expected, $this->service->getValidClasses());
+
+        /** @var CacheInterface $cache */
+        $cache = Injector::inst()->get(CacheInterface::class . '.SolrCache');
+        $this->assertEquals($expected, $cache->get('ValidClasses'));
+
     }
 
     public function testGetSetAdmin()


### PR DESCRIPTION
Adding PHP based caching to speed up configure and indexing.

- At step one. More to come. Includes a few proper fixes for open issues due to caching fixing them.