### PR TITLE
NEW: Allow Criteria objects to be passed to filter/exclude (closes #205)

### DIFF
--- a/docs/03-Usage.md
+++ b/docs/03-Usage.md
@@ -259,6 +259,9 @@ Looking at the `tests` folder, there is a `TestIndexFour`. This index is not loa
 To search, here's an example using all the features, and setting the resulting outcome from the search
 onto the current `Controller` to be useable in templates.
 
+More advanced filter options are available, see the [Advanced filters & excludes](04-Advanced-Options/05-Filters-excludes.md)
+page for more information.
+
 ```php
 class SearchController extends PageController
 {

--- a/docs/04-Advanced-Options/05-Filters-excludes.md
+++ b/docs/04-Advanced-Options/05-Filters-excludes.md
@@ -1,0 +1,40 @@
+# Advanced filters & excludes
+
+When performing a search, in addition to simple single-value and array-of-value filters, it’s possible
+to build more complex filter/exclude criteria. Some examples of this include:
+
+- Range filters (greater than/less than)
+- Geospatial search
+- Partial match filters (starts with/ends with)
+
+## Usage
+
+Advanced search/exclude filters are constructed from `Criteria` objects, from the [MinimalCode Solr
+Search Criteria](https://github.com/minimalcode-org/search) package. More information and usage 
+examples are available [here](https://github.com/minimalcode-org/minimalcode-parent/wiki/4.1-Solr-Search-%28Php%29).
+
+When passing a `Criteria` object to `addFilter` or `addExclude`, the first argument (usually the
+field name) can be set to any string value.
+
+```php
+$query = new BaseQuery();
+
+// Simple date filter - exclude any pages which have an embargo date in the future
+$criteria = Criteria::where('SiteTree_Embargo')
+    ->greaterThanEqual('NOW');
+$query->addExclude('embargo', $criteria);
+
+// Starts with/ends with filter
+$criteria = Criteria::where('SiteTree_Title')
+    ->startsWith('prefix')
+    ->endsWith('suffix');
+$query->addFilter('title-partial-match', $criteria);
+
+// Nested criteria
+$topLevel = Criteria::where('SiteTree_ParentID')
+    ->is(0);
+$criteria = Criteria::where('SiteTree_Title')
+    ->startsWith('test')
+    ->andWhere($topLevel);
+$query->addFilter('top-level-test-pages', $criteria);
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Advanced searching for SilverStripe with Solr. Versions 4-8+ are supported.
     02. [Boosting](04-Advanced-Options/02-Boosting.md)
     03. [Fuzzy search](04-Advanced-Options/03-Fuzzy-search.md)
     04. [Elevation [WIP]](04-Advanced-Options/04-Elevation.md)
+    05. [Advanced filters & excludes](04-Advanced-Options/05-Filters-excludes.md)
 05. [Customisation](05-Customisation.md)
 06. [CMS Usage](06-CMS-Usage.md)
 07. [Debugging](07-Debugging.md)

--- a/src/Traits/QueryTraits/BaseQueryTrait.php
+++ b/src/Traits/QueryTraits/BaseQueryTrait.php
@@ -10,6 +10,8 @@
 
 namespace Firesphere\SolrSearch\Traits;
 
+use Minimalcode\Search\Criteria;
+
 /**
  * Trait BaseQueryTrait Extraction from the BaseQuery class to keep things readable.
  *
@@ -83,7 +85,7 @@ trait BaseQueryTrait
      * Adds filters to filter on by value
      *
      * @param string $field Field to filter on
-     * @param string|array $value Value for this field
+     * @param string|array|Criteria $value Value for this field
      * @return $this
      */
     public function addFilter($field, $value): self
@@ -112,7 +114,7 @@ trait BaseQueryTrait
      * Exclude fields from the search action
      *
      * @param string $field
-     * @param string|array $value
+     * @param string|array|Criteria $value
      * @return $this
      */
     public function addExclude($field, $value): self


### PR DESCRIPTION
@Firesphere I know you said you preferred an `$escape` argument, but I wanted to show how simple the change set would be for accepting `Criteria` objects as filters. Usage example:

```php
$criteria = Criteria::where('Document_Embargo')
    ->greaterThanEqual('NOW');
$query->addExclude('Document_Embargo', $criteria);
```

This also means we can leave the existing escaping in `QueryComponentFactory` untouched