### PR TITLE
FIX: Extension hook is broken on reports Gridfield

### DIFF
--- a/src/Extensions/GridFieldExtension.php
+++ b/src/Extensions/GridFieldExtension.php
@@ -13,6 +13,7 @@ use Firesphere\SolrSearch\Models\SolrLog;
 use SilverStripe\Core\Extension;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\View\ViewableData;
 
 /**
  * Class GridFieldExtension
@@ -32,7 +33,7 @@ class GridFieldExtension extends Extension
      * @param string $index
      * @param DataObject $record
      */
-    public function updateNewRowClasses(array &$classes, int $total, string $index, DataObject $record)
+    public function updateNewRowClasses(array &$classes, int $total, string $index, ViewableData $record)
     {
         if ($record instanceof SolrLog) {
             $classes[] = $record->getExtraClass();


### PR DESCRIPTION
The `GridfieldExtension::updateNewRowClasses` causes an error when opening the Reports modeladmin. This is because the $report object passed in does not descend from DataObject, which is enforced by type-hinting.  Changing it to ViewableData will allow the extension to function on GridFields that are populated by ArrayData. 
